### PR TITLE
feat: add --include-undocumented flag to generate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ See `DEVELOPMENT.md` for full details on the test framework and documenting devi
 - **`@example` continuation** — Uses `^[\s]*#[ ]+` (one or more spaces after `#`). A bare `#` (no space) ends the example. Implemented in `collectExampleLines()`.
 - **`@description` collection** — `collectUntilNextTag()` stops at `@`-tagged lines but continues through bare `#` blank comment lines.
 - **`@label` parsing** — Comma-separated values on a single line, split and trimmed. Multiple `@label` lines accumulate. Stored as `Labels []string` on `FuncDoc`.
+- **Bare function declarations are segmented too** — A function declaration with no preceding comment block becomes a `FuncDocBlock` with `Comments.Lines` empty. `parseFuncBlock` emits a bare `FuncDoc{Name: ...}` in the current sticky section only when `ParseOptions.IncludeUndocumented` is set; otherwise it returns silently. Future edits to the segmenter loop or to `parseFuncBlock`'s early-return must preserve this.
+- **`ExtractFuncName` filters shell reserved words** — Returns `""` for `for`, `while`, `until`, `case`, etc., because the function-decl regex matches constructs like `for ((...))`. Extending shell-keyword coverage means updating `shellReservedWords` in `segmenter.go`.
 
 ## Reference Implementation
 

--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ shdoc-ng lsp         Run the LSP server (stdio)
 shdoc-ng generate [flags]
 
 Flags:
-  -i, --input string      Input file (default stdin)
-  -o, --output string     Output file (default stdout)
-      --format string     Output format: markdown, html, json (default "markdown")
-      --template string   Use a custom template file
+  -i, --input string         Input file (default stdin)
+  -o, --output string        Output file (default stdout)
+      --format string        Output format: markdown, html, json (default "markdown")
+      --template string      Use a custom template file
+      --include-undocumented List functions with no documentation alongside documented ones
 ```
 
 ### check
@@ -209,6 +210,10 @@ repos:
     hooks:
       - id: shdoc-ng-check
 ```
+
+## Wiki
+
+The [project wiki](https://github.com/jdevera/shdoc-ng/wiki) contains additional use cases.
 
 ## Building from Source
 

--- a/cmd/shdoc-ng/generate.go
+++ b/cmd/shdoc-ng/generate.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	genFormat       string
-	genInputFile    string
-	genOutputFile   string
-	genTemplateFile string
+	genFormat              string
+	genInputFile           string
+	genOutputFile          string
+	genTemplateFile        string
+	genIncludeUndocumented bool
 )
 
 var defaultTemplates = map[string]string{
@@ -41,6 +42,7 @@ func init() {
 	generateCmd.Flags().StringVarP(&genInputFile, "input", "i", "-", "Input file (- for stdin)")
 	generateCmd.Flags().StringVarP(&genOutputFile, "output", "o", "-", "Output file (- for stdout)")
 	generateCmd.Flags().StringVar(&genTemplateFile, "template", "", "Use a custom template file instead of the built-in one")
+	generateCmd.Flags().BoolVar(&genIncludeUndocumented, "include-undocumented", false, "List functions with no documentation under a synthetic 'Undocumented' section")
 	rootCmd.AddCommand(generateCmd)
 }
 
@@ -78,7 +80,9 @@ func runGenerate(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("reading input: %w", err)
 	}
 
-	doc, warns := shdoc.ParseDocument(string(src))
+	doc, warns := shdoc.ParseDocumentWithOptions(string(src), shdoc.ParseOptions{
+		IncludeUndocumented: genIncludeUndocumented,
+	})
 
 	warnFile := genInputFile
 	if warnFile == "-" {

--- a/shdoc/blockparser.go
+++ b/shdoc/blockparser.go
@@ -698,15 +698,9 @@ func (bp *blockParser) parseFuncBlock(block ParsedBlock) {
 	finalDesc := cleanDescription(pendingDesc)
 	docblock.Description = finalDesc
 
-	if !docblock.hasDocumentation() && docblock.Description == "" {
-		if bp.opts.IncludeUndocumented && block.FuncName != "" {
-			sec := &bp.doc.Sections[bp.currentSection]
-			sec.Functions = append(sec.Functions, FuncDoc{Name: block.FuncName})
-		}
-		return
-	}
-
 	// Sort args numerically ($1, $2, …), with $@ last.
+	// Must run before hasDocumentation() so an @arg-only function still
+	// reports as documented and keeps its args in the output.
 	sortKeys := make([]int, 0, len(tempArgs))
 	for k := range tempArgs {
 		sortKeys = append(sortKeys, k)
@@ -714,6 +708,14 @@ func (bp *blockParser) parseFuncBlock(block ParsedBlock) {
 	sort.Ints(sortKeys)
 	for _, k := range sortKeys {
 		docblock.Args = append(docblock.Args, tempArgs[k])
+	}
+
+	if !docblock.hasDocumentation() && docblock.Description == "" {
+		if bp.opts.IncludeUndocumented && block.FuncName != "" {
+			sec := &bp.doc.Sections[bp.currentSection]
+			sec.Functions = append(sec.Functions, FuncDoc{Name: block.FuncName})
+		}
+		return
 	}
 
 	docblock.Name = block.FuncName

--- a/shdoc/blockparser.go
+++ b/shdoc/blockparser.go
@@ -52,17 +52,32 @@ var (
 	bpCleanTrailingRe = regexp.MustCompile(`[\s\n]*$`)
 )
 
+// ParseOptions controls optional parsing behavior.
+type ParseOptions struct {
+	// IncludeUndocumented surfaces functions that have no documentation as
+	// bare FuncDoc entries (Name only) placed in whichever section is
+	// currently active at the point of declaration. @internal functions are
+	// still excluded.
+	IncludeUndocumented bool
+}
+
 // ParseDocument parses src and returns the document and any warnings.
 func ParseDocument(src string) (Document, []Warning) {
-	lines := LexLines(src)
-	blocks := SegmentBlocks(lines)
-	return ParseBlocks(blocks)
+	return ParseDocumentWithOptions(src, ParseOptions{})
+}
+
+// ParseDocumentWithOptions parses src with the given options.
+func ParseDocumentWithOptions(src string, opts ParseOptions) (Document, []Warning) {
+	return parseBlocksWithOptions(SegmentBlocks(LexLines(src)), opts)
 }
 
 // ParseBlocks parses pre-segmented blocks and returns the document and any warnings.
 func ParseBlocks(blocks []ParsedBlock) (Document, []Warning) {
-	bp := &blockParser{}
-	// Start with one unnamed section for functions before any @section tag.
+	return parseBlocksWithOptions(blocks, ParseOptions{})
+}
+
+func parseBlocksWithOptions(blocks []ParsedBlock, opts ParseOptions) (Document, []Warning) {
+	bp := &blockParser{opts: opts}
 	bp.doc.Sections = []Section{{}}
 	bp.currentSection = 0
 
@@ -74,7 +89,6 @@ func ParseBlocks(blocks []ParsedBlock) (Document, []Warning) {
 		}
 	}
 
-	// Prune sections with no functions.
 	var pruned []Section
 	for _, s := range bp.doc.Sections {
 		if len(s.Functions) == 0 {
@@ -91,6 +105,7 @@ type blockParser struct {
 	doc            Document
 	warns          []Warning
 	currentSection int // index into doc.Sections
+	opts           ParseOptions
 	// Track which file-level singleton tags have been set, to warn on duplicates.
 	seenFileTags map[string]int // tag -> first line number
 }
@@ -684,6 +699,10 @@ func (bp *blockParser) parseFuncBlock(block ParsedBlock) {
 	docblock.Description = finalDesc
 
 	if !docblock.hasDocumentation() && docblock.Description == "" {
+		if bp.opts.IncludeUndocumented && block.FuncName != "" {
+			sec := &bp.doc.Sections[bp.currentSection]
+			sec.Functions = append(sec.Functions, FuncDoc{Name: block.FuncName})
+		}
 		return
 	}
 

--- a/shdoc/segmenter.go
+++ b/shdoc/segmenter.go
@@ -46,6 +46,16 @@ func SegmentBlocks(lines []LexedLine) []ParsedBlock {
 
 	for i < n {
 		if lines[i].Kind != LineComment {
+			if lines[i].Kind == LineCode {
+				if name, consumed := matchBareFuncDecl(lines, i); consumed > 0 {
+					blocks = append(blocks, ParsedBlock{
+						Kind:     FuncDocBlockKind,
+						FuncName: name,
+					})
+					i += consumed
+					continue
+				}
+			}
 			i++
 			continue
 		}
@@ -102,6 +112,25 @@ func SegmentBlocks(lines []LexedLine) []ParsedBlock {
 // IsFuncDecl reports whether line looks like a shell function declaration.
 func IsFuncDecl(line string) bool {
 	return segFuncDeclWithBrace.MatchString(line)
+}
+
+// matchBareFuncDecl checks whether lines[i] (assumed LineCode) is the start of
+// a function declaration, using the same recognition rules SegmentBlocks
+// applies to a function that follows a comment block. Returns the function
+// name and the number of lines consumed (1 or 2). Returns "", 0 if no match.
+func matchBareFuncDecl(lines []LexedLine, i int) (string, int) {
+	raw := lines[i].Raw
+	if segFuncDeclWithBrace.MatchString(raw) {
+		return ExtractFuncName(raw), 1
+	}
+	if segFuncDeclWithoutBrace.MatchString(raw) {
+		if i+1 < len(lines) && (lines[i+1].Kind == LineBlank || lines[i+1].Kind == LineCode) {
+			if segLoneBrace.MatchString(lines[i+1].Raw) {
+				return ExtractFuncName(raw), 2
+			}
+		}
+	}
+	return "", 0
 }
 
 // ExtractFuncName pulls the function name from a declaration line.

--- a/shdoc/segmenter.go
+++ b/shdoc/segmenter.go
@@ -109,9 +109,19 @@ func SegmentBlocks(lines []LexedLine) []ParsedBlock {
 	return blocks
 }
 
+// shellReservedWords are shell keywords that can appear at the start of a
+// compound command and superficially match the function-declaration regex
+// (e.g. `for ((...))`, `while ((...))`). They can never be function names.
+var shellReservedWords = map[string]bool{
+	"if": true, "then": true, "else": true, "elif": true, "fi": true,
+	"case": true, "esac": true,
+	"for": true, "while": true, "until": true, "do": true, "done": true,
+	"select": true, "function": true, "in": true, "time": true,
+}
+
 // IsFuncDecl reports whether line looks like a shell function declaration.
 func IsFuncDecl(line string) bool {
-	return segFuncDeclWithBrace.MatchString(line)
+	return segFuncDeclWithBrace.MatchString(line) && ExtractFuncName(line) != ""
 }
 
 // matchBareFuncDecl checks whether lines[i] (assumed LineCode) is the start of
@@ -121,12 +131,16 @@ func IsFuncDecl(line string) bool {
 func matchBareFuncDecl(lines []LexedLine, i int) (string, int) {
 	raw := lines[i].Raw
 	if segFuncDeclWithBrace.MatchString(raw) {
-		return ExtractFuncName(raw), 1
+		if name := ExtractFuncName(raw); name != "" {
+			return name, 1
+		}
 	}
 	if segFuncDeclWithoutBrace.MatchString(raw) {
 		if i+1 < len(lines) && (lines[i+1].Kind == LineBlank || lines[i+1].Kind == LineCode) {
 			if segLoneBrace.MatchString(lines[i+1].Raw) {
-				return ExtractFuncName(raw), 2
+				if name := ExtractFuncName(raw); name != "" {
+					return name, 2
+				}
 			}
 		}
 	}
@@ -134,9 +148,15 @@ func matchBareFuncDecl(lines []LexedLine, i int) (string, int) {
 }
 
 // ExtractFuncName pulls the function name from a declaration line.
+// Returns "" if the matched identifier is a shell reserved word (e.g. `for`
+// in `for ((i=0; i<10; i++))`).
 func ExtractFuncName(line string) string {
-	if m := segFuncNameRe.FindStringSubmatch(line); m != nil {
-		return m[1]
+	m := segFuncNameRe.FindStringSubmatch(line)
+	if m == nil {
+		return ""
 	}
-	return ""
+	if shellReservedWords[m[1]] {
+		return ""
+	}
+	return m[1]
 }

--- a/shdoc/segmenter_test.go
+++ b/shdoc/segmenter_test.go
@@ -90,6 +90,58 @@ brace_next()
 	}
 }
 
+func TestSegmenterRejectsShellKeywords(t *testing.T) {
+	// Shell reserved words can never be function names. The segmenter regex
+	// must not mistake constructs like `for ((...))` or `while ((...))` for
+	// function declarations.
+	src := `for ((i=0; i<10; i++)); do
+    echo "$i"
+done
+
+while ((n > 0)); do
+    n=$((n - 1))
+done
+
+until ((done)); do
+    sleep 1
+done
+
+case "$x" in
+    foo) echo foo ;;
+esac
+
+# @description A real function.
+real_func() {
+    echo "hi"
+}
+`
+	blocks := SegmentBlocks(LexLines(src))
+
+	var funcNames []string
+	for _, b := range blocks {
+		if b.Kind == FuncDocBlockKind {
+			funcNames = append(funcNames, b.FuncName)
+		}
+	}
+
+	want := []string{"real_func"}
+	if len(funcNames) != len(want) || funcNames[0] != want[0] {
+		t.Errorf("segmented funcs = %v, want %v (shell keywords must not be matched as function names)", funcNames, want)
+	}
+
+	// Also verify the line-by-line predicate.
+	for _, line := range []string{
+		"for ((i=0; i<10; i++)); do",
+		"while ((n > 0)); do",
+		"until ((done)); do",
+		"case \"$x\" in",
+	} {
+		if IsFuncDecl(line) {
+			t.Errorf("IsFuncDecl(%q) = true, want false", line)
+		}
+	}
+}
+
 func TestIsFuncDecl(t *testing.T) {
 	tests := []struct {
 		line string

--- a/shdoc/segmenter_test.go
+++ b/shdoc/segmenter_test.go
@@ -42,6 +42,54 @@ greet() { :; }`
 	}
 }
 
+func TestSegmentBareFuncDecls(t *testing.T) {
+	src := `# @description Documented.
+greet() {
+    echo hi
+}
+
+undocumented_one() {
+    echo nope
+}
+
+# A random comment that is not a doc block.
+undocumented_two() {
+    echo nope
+}
+
+brace_next()
+{
+    echo split
+}
+`
+	blocks := SegmentBlocks(LexLines(src))
+
+	var funcNames []string
+	for _, b := range blocks {
+		if b.Kind == FuncDocBlockKind {
+			funcNames = append(funcNames, b.FuncName)
+		}
+	}
+	want := []string{"greet", "undocumented_one", "undocumented_two", "brace_next"}
+	if len(funcNames) != len(want) {
+		t.Fatalf("segmented funcs = %v, want %v", funcNames, want)
+	}
+	for i := range want {
+		if funcNames[i] != want[i] {
+			t.Errorf("func[%d] = %q, want %q", i, funcNames[i], want[i])
+		}
+	}
+
+	// undocumented_one has no preceding comments — its block must have empty Comments.
+	for _, b := range blocks {
+		if b.FuncName == "undocumented_one" {
+			if len(b.Comments.Lines) != 0 {
+				t.Errorf("bare func block should have no comment lines, got %d", len(b.Comments.Lines))
+			}
+		}
+	}
+}
+
 func TestIsFuncDecl(t *testing.T) {
 	tests := []struct {
 		line string

--- a/shdoc/shdoc_test.go
+++ b/shdoc/shdoc_test.go
@@ -320,6 +320,37 @@ farewell() {
 	}
 }
 
+func TestArgOnlyFunctionKeepsArgs(t *testing.T) {
+	src := `# @arg $1 string A name to greet.
+# @arg $2 int How many times.
+greet() {
+    echo "$1 $2"
+}
+`
+	doc, _ := ParseDocument(src)
+	all := doc.AllFunctions()
+	if len(all) != 1 {
+		names := make([]string, len(all))
+		for i, f := range all {
+			names[i] = f.Name
+		}
+		t.Fatalf("expected 1 function, got %d: %v", len(all), names)
+	}
+	f := all[0]
+	if f.Name != "greet" {
+		t.Errorf("Name = %q, want %q", f.Name, "greet")
+	}
+	if len(f.Args) != 2 {
+		t.Fatalf("Args len = %d, want 2 (function with only @arg should still keep them)", len(f.Args))
+	}
+	if f.Args[0].Name != "$1" || f.Args[0].Type != "string" || f.Args[0].Description != "A name to greet." {
+		t.Errorf("Args[0] = %+v, want {$1 string A name to greet.}", f.Args[0])
+	}
+	if f.Args[1].Name != "$2" || f.Args[1].Type != "int" || f.Args[1].Description != "How many times." {
+		t.Errorf("Args[1] = %+v, want {$2 int How many times.}", f.Args[1])
+	}
+}
+
 func TestIncludeUndocumented(t *testing.T) {
 	src := `#!/usr/bin/env bash
 

--- a/shdoc/shdoc_test.go
+++ b/shdoc/shdoc_test.go
@@ -320,6 +320,108 @@ farewell() {
 	}
 }
 
+func TestIncludeUndocumented(t *testing.T) {
+	src := `#!/usr/bin/env bash
+
+# @description Documented top-level.
+documented_top() {
+    echo "hi"
+}
+
+bare_top() {
+    echo "no docs"
+}
+
+# @section Utils
+# @description Helper functions.
+
+# @description Documented in Utils.
+documented_utils() {
+    echo "hi"
+}
+
+bare_utils() {
+    echo "no docs"
+}
+
+# A random comment that does not form a doc block.
+bare_with_random_comment() {
+    echo "still no docs"
+}
+
+# @description Hidden helper.
+# @internal
+hidden_utils() {
+    echo "internal"
+}
+`
+
+	t.Run("default behavior unchanged", func(t *testing.T) {
+		doc, _ := ParseDocument(src)
+		var names []string
+		for _, f := range doc.AllFunctions() {
+			names = append(names, f.Name)
+		}
+		want := []string{"documented_top", "documented_utils"}
+		if !equalStrings(names, want) {
+			t.Fatalf("default output funcs = %v, want %v", names, want)
+		}
+	})
+
+	t.Run("with include-undocumented places bare funcs in their natural section", func(t *testing.T) {
+		doc, _ := ParseDocumentWithOptions(src, ParseOptions{IncludeUndocumented: true})
+
+		secByName := map[string][]string{}
+		for _, s := range doc.Sections {
+			for _, f := range s.Functions {
+				secByName[s.Name] = append(secByName[s.Name], f.Name)
+			}
+		}
+
+		// Top-level (unnamed) section: documented_top + bare_top.
+		if got, want := secByName[""], []string{"documented_top", "bare_top"}; !equalStrings(got, want) {
+			t.Errorf("unnamed section funcs = %v, want %v", got, want)
+		}
+
+		// Utils section: documented_utils, bare_utils, bare_with_random_comment.
+		// hidden_utils (@internal) must be excluded.
+		want := []string{"documented_utils", "bare_utils", "bare_with_random_comment"}
+		if got := secByName["Utils"]; !equalStrings(got, want) {
+			t.Errorf("Utils section funcs = %v, want %v", got, want)
+		}
+
+		// No synthetic "Undocumented" section.
+		for _, s := range doc.Sections {
+			if s.Name == "Undocumented" {
+				t.Errorf("did not expect a synthetic 'Undocumented' section")
+			}
+		}
+
+		// Bare entries carry no doc content.
+		for _, s := range doc.Sections {
+			for _, f := range s.Functions {
+				if strings.HasPrefix(f.Name, "bare_") {
+					if f.hasDocumentation() || f.Description != "" {
+						t.Errorf("bare func %q unexpectedly carries doc content: %+v", f.Name, f)
+					}
+				}
+			}
+		}
+	})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestExternal(t *testing.T) {
 	shdocCmd := os.Getenv("SHDOC_CMD")
 	if shdocCmd == "" {


### PR DESCRIPTION
## Summary

- Adds `--include-undocumented` to `shdoc-ng generate` (opt-in, default off).
- Functions with no doc block are surfaced as bare `FuncDoc` entries (name only) **in whichever `@section` is currently active at their declaration**, not in a synthetic bucket.
- `@internal` is still respected.
- JSON schema needs no changes — `name` is the only required field on `FuncDoc`, so bare entries already conform.
- Public Go API gains `ParseDocumentWithOptions(src, ParseOptions{})`; `ParseDocument` becomes a thin wrapper, so existing callers (CLI `check`, LSP server, library users) are unchanged.

Refs #8.

## Use case from #8 : building a CI gate around shdoc-ng

The new flag gives you everything you need to enforce "all functions documented" externally, while keeping shdoc-ng a documentation generator (not a linter).

### Example check script

```bash
#!/usr/bin/env bash
# check-docs.sh — fail if any function lacks a @description.
set -euo pipefail

script=${1:?usage: check-docs.sh <script.sh>}

undocumented=$(
  shdoc-ng generate --format json --include-undocumented -i "$script" \
    | jq -r '.sections[].functions[] | select(.description == null) | .name'
)

if [[ -n "$undocumented" ]]; then
  echo "Undocumented functions in $script:" >&2
  printf '  - %s\n' $undocumented >&2
  exit 1
fi

echo "OK: all functions in $script are documented."
```

### Example output when it fails

Given a script `mix.sh` with a mix of documented, undocumented, and `@internal` functions:

```
$ ./check-docs.sh mix.sh
Undocumented functions in mix.sh:
  - bare_top_level
  - subtract
  - multiply
  - upper
$ echo $?
1
```

And on a fully documented script:

```
$ ./check-docs.sh fully-documented.sh
OK: all functions in fully-documented.sh are documented.
$ echo $?
0
```

### Notes

- `@internal` functions are excluded from the output entirely, so they won't trip the check.
- The example filter uses `select(.description == null)`. A function documented only with, say, `@arg` and no `@description` would pass this filter. If you want stricter "any documentation at all," widen the filter (`select((.description // .args // .options // .exitcodes // .example) == null)`) or pick the fields that matter for your project.

## Test plan

- [x] `go test -count=1 ./...` — all green, including new `TestSegmentBareFuncDecls` (segmenter) and `TestIncludeUndocumented` (parser-level behavior, section placement, `@internal` exclusion).
- [x] JSON schema regenerated and diffed against `main` — byte-identical.
- [x] Smoke-tested `--format markdown`, `--format html`, `--format json` on a mixed-doc script, both with and without the flag.
- [x] Confirmed `check`, `lsp`, `schema`, and `template` subcommands are unaffected (no flag, no API change at their callsites).
