### PR TITLE
feat: add --include-internal and --include-all flags to generate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ See `DEVELOPMENT.md` for full details on the test framework and documenting devi
 - **`@label` parsing** — Comma-separated values on a single line, split and trimmed. Multiple `@label` lines accumulate. Stored as `Labels []string` on `FuncDoc`.
 - **Bare function declarations are segmented too** — A function declaration with no preceding comment block becomes a `FuncDocBlock` with `Comments.Lines` empty. `parseFuncBlock` emits a bare `FuncDoc{Name: ...}` in the current sticky section only when `ParseOptions.IncludeUndocumented` is set; otherwise it returns silently. Future edits to the segmenter loop or to `parseFuncBlock`'s early-return must preserve this.
 - **`ExtractFuncName` filters shell reserved words** — Returns `""` for `for`, `while`, `until`, `case`, etc., because the function-decl regex matches constructs like `for ((...))`. Extending shell-keyword coverage means updating `shellReservedWords` in `segmenter.go`.
+- **`@internal` is conditionally suppressed** — `parseFuncBlock` returns early on `@internal` unless `ParseOptions.IncludeInternal` is set. When included, the function carries `IsInternal=true` (templates render an `_(internal)_` marker) and the bare-add path under `IncludeUndocumented` propagates the flag too.
 
 ## Reference Implementation
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The HTML output uses the [Catppuccin](https://catppuccin.com) color palette.
 | `@stderr` | Description of stderr output |
 | `@see` | Cross-reference (function, URL, path, or markdown link) |
 | `@section` | Group following functions under a section heading |
-| `@internal` | Exclude function from output |
+| `@internal` | Exclude function from default output (use `--include-internal` to surface) |
 | `@deprecated` | Mark as deprecated, with optional message |
 | `@warning` / `@warn` | Usage warning |
 | `@label` | Freeform labels for categorization (comma-separated) |
@@ -129,6 +129,8 @@ Flags:
       --format string        Output format: markdown, html, json (default "markdown")
       --template string      Use a custom template file
       --include-undocumented List functions with no documentation alongside documented ones
+      --include-internal     Surface @internal functions (marked as internal in the output)
+      --include-all          Shorthand for --include-undocumented --include-internal
 ```
 
 ### check

--- a/cmd/shdoc-ng/generate.go
+++ b/cmd/shdoc-ng/generate.go
@@ -16,6 +16,8 @@ var (
 	genOutputFile          string
 	genTemplateFile        string
 	genIncludeUndocumented bool
+	genIncludeInternal     bool
+	genIncludeAll          bool
 )
 
 var defaultTemplates = map[string]string{
@@ -42,7 +44,9 @@ func init() {
 	generateCmd.Flags().StringVarP(&genInputFile, "input", "i", "-", "Input file (- for stdin)")
 	generateCmd.Flags().StringVarP(&genOutputFile, "output", "o", "-", "Output file (- for stdout)")
 	generateCmd.Flags().StringVar(&genTemplateFile, "template", "", "Use a custom template file instead of the built-in one")
-	generateCmd.Flags().BoolVar(&genIncludeUndocumented, "include-undocumented", false, "List functions with no documentation under a synthetic 'Undocumented' section")
+	generateCmd.Flags().BoolVar(&genIncludeUndocumented, "include-undocumented", false, "List functions with no documentation alongside documented ones")
+	generateCmd.Flags().BoolVar(&genIncludeInternal, "include-internal", false, "Surface @internal functions, marked as internal")
+	generateCmd.Flags().BoolVar(&genIncludeAll, "include-all", false, "Shorthand for --include-undocumented --include-internal")
 	rootCmd.AddCommand(generateCmd)
 }
 
@@ -81,7 +85,8 @@ func runGenerate(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	doc, warns := shdoc.ParseDocumentWithOptions(string(src), shdoc.ParseOptions{
-		IncludeUndocumented: genIncludeUndocumented,
+		IncludeUndocumented: genIncludeUndocumented || genIncludeAll,
+		IncludeInternal:     genIncludeInternal || genIncludeAll,
 	})
 
 	warnFile := genInputFile

--- a/schema.json
+++ b/schema.json
@@ -132,6 +132,10 @@
                   "description": "True if the function is deprecated (@deprecated)",
                   "type": "boolean"
                 },
+                "is_internal": {
+                  "description": "True if the function is marked @internal",
+                  "type": "boolean"
+                },
                 "is_noargs": {
                   "description": "True if the function explicitly takes no arguments (@noargs)",
                   "type": "boolean"

--- a/shdoc/blockparser.go
+++ b/shdoc/blockparser.go
@@ -57,8 +57,13 @@ type ParseOptions struct {
 	// IncludeUndocumented surfaces functions that have no documentation as
 	// bare FuncDoc entries (Name only) placed in whichever section is
 	// currently active at the point of declaration. @internal functions are
-	// still excluded.
+	// still excluded unless IncludeInternal is also set.
 	IncludeUndocumented bool
+
+	// IncludeInternal surfaces functions marked @internal. They appear in
+	// the output like any documented function but carry IsInternal=true so
+	// consumers and templates can distinguish them.
+	IncludeInternal bool
 }
 
 // ParseDocument parses src and returns the document and any warnings.
@@ -692,7 +697,10 @@ func (bp *blockParser) parseFuncBlock(block ParsedBlock) {
 	}
 
 	if isInternal {
-		return
+		if !bp.opts.IncludeInternal {
+			return
+		}
+		docblock.IsInternal = true
 	}
 
 	finalDesc := cleanDescription(pendingDesc)
@@ -713,7 +721,10 @@ func (bp *blockParser) parseFuncBlock(block ParsedBlock) {
 	if !docblock.hasDocumentation() && docblock.Description == "" {
 		if bp.opts.IncludeUndocumented && block.FuncName != "" {
 			sec := &bp.doc.Sections[bp.currentSection]
-			sec.Functions = append(sec.Functions, FuncDoc{Name: block.FuncName})
+			sec.Functions = append(sec.Functions, FuncDoc{
+				Name:       block.FuncName,
+				IsInternal: docblock.IsInternal,
+			})
 		}
 		return
 	}

--- a/shdoc/shdoc_test.go
+++ b/shdoc/shdoc_test.go
@@ -453,6 +453,101 @@ func equalStrings(a, b []string) bool {
 	return true
 }
 
+func TestIncludeInternal(t *testing.T) {
+	src := `# @description Public helper.
+public_helper() {
+    echo "hi"
+}
+
+# @description Hidden helper.
+# @internal
+hidden_helper() {
+    echo "internal"
+}
+
+# @internal
+bare_internal() {
+    echo "internal, no description"
+}
+`
+
+	collect := func(doc Document) map[string]FuncDoc {
+		out := map[string]FuncDoc{}
+		for _, s := range doc.Sections {
+			for _, f := range s.Functions {
+				out[f.Name] = f
+			}
+		}
+		return out
+	}
+
+	t.Run("default excludes @internal", func(t *testing.T) {
+		doc, _ := ParseDocument(src)
+		got := collect(doc)
+		if _, ok := got["public_helper"]; !ok {
+			t.Errorf("expected public_helper in output")
+		}
+		if _, ok := got["hidden_helper"]; ok {
+			t.Errorf("expected hidden_helper to be excluded by default")
+		}
+		if _, ok := got["bare_internal"]; ok {
+			t.Errorf("expected bare_internal to be excluded by default")
+		}
+	})
+
+	t.Run("IncludeInternal surfaces documented @internal with IsInternal=true", func(t *testing.T) {
+		doc, _ := ParseDocumentWithOptions(src, ParseOptions{IncludeInternal: true})
+		got := collect(doc)
+		f, ok := got["hidden_helper"]
+		if !ok {
+			t.Fatalf("expected hidden_helper in output with IncludeInternal")
+		}
+		if !f.IsInternal {
+			t.Errorf("hidden_helper.IsInternal = false, want true")
+		}
+		if f.Description != "Hidden helper." {
+			t.Errorf("hidden_helper.Description = %q, want %q", f.Description, "Hidden helper.")
+		}
+		// bare_internal (no description) is still dropped without IncludeUndocumented.
+		if _, ok := got["bare_internal"]; ok {
+			t.Errorf("bare_internal should still be dropped without IncludeUndocumented")
+		}
+		// Public function still there, not flagged internal.
+		if pf := got["public_helper"]; pf.IsInternal {
+			t.Errorf("public_helper.IsInternal = true, want false")
+		}
+	})
+
+	t.Run("IncludeInternal + IncludeUndocumented surfaces bare @internal too", func(t *testing.T) {
+		doc, _ := ParseDocumentWithOptions(src, ParseOptions{
+			IncludeInternal:     true,
+			IncludeUndocumented: true,
+		})
+		got := collect(doc)
+		f, ok := got["bare_internal"]
+		if !ok {
+			t.Fatalf("expected bare_internal with both flags set")
+		}
+		if !f.IsInternal {
+			t.Errorf("bare_internal.IsInternal = false, want true (preserved through bare-add path)")
+		}
+		if f.Description != "" {
+			t.Errorf("bare_internal.Description should be empty, got %q", f.Description)
+		}
+	})
+
+	t.Run("IncludeUndocumented alone still excludes @internal", func(t *testing.T) {
+		doc, _ := ParseDocumentWithOptions(src, ParseOptions{IncludeUndocumented: true})
+		got := collect(doc)
+		if _, ok := got["hidden_helper"]; ok {
+			t.Errorf("hidden_helper should remain excluded with IncludeUndocumented alone")
+		}
+		if _, ok := got["bare_internal"]; ok {
+			t.Errorf("bare_internal should remain excluded with IncludeUndocumented alone")
+		}
+	})
+}
+
 func TestExternal(t *testing.T) {
 	shdocCmd := os.Getenv("SHDOC_CMD")
 	if shdocCmd == "" {

--- a/shdoc/templates/html.tmpl
+++ b/shdoc/templates/html.tmpl
@@ -11,7 +11,7 @@
 <section class="func" id="{{slug .Name}}">
 
   <div class="func-header">
-    <h3 class="func-name"><span class="func-sigil">fn</span> {{.Name | html}}{{- if .Labels}}
+    <h3 class="func-name"><span class="func-sigil">fn</span> {{.Name | html}}{{- if .IsInternal}} <em class="func-internal">(internal)</em>{{end}}{{- if .Labels}}
       {{- range .Labels}} <span class="func-label">{{. | html}}</span>{{end}}
     {{- end}}</h3>
     <a href="#{{slug .Name}}" class="func-anchor" aria-label="permalink">¶</a>

--- a/shdoc/templates/markdown.tmpl
+++ b/shdoc/templates/markdown.tmpl
@@ -163,7 +163,7 @@ The "### FuncName" heading, followed by all sections.
 Each sec* call adds "\n\ncontent" or nothing; the final {{"\n"}} closes the block.
 */ -}}
 {{- define "funcBlock" -}}
-### {{.Name}}
+### {{.Name}}{{if .IsInternal}} _(internal)_{{end}}
 {{- template "secDeprecated"  .}}
 {{- template "secDescription" .}}
 {{- template "secWarnings"    .}}

--- a/shdoc/types.go
+++ b/shdoc/types.go
@@ -48,6 +48,7 @@ type FuncDoc struct {
 	Warnings    []string      `json:"warnings,omitempty"          desc:"Warnings about usage or behavior (@warning)"`
 	IsDeprecated    bool          `json:"is_deprecated,omitempty"      desc:"True if the function is deprecated (@deprecated)"`
 	DeprecatedMessage string      `json:"deprecated_message,omitempty" desc:"Deprecation notice, if provided (@deprecated message)"`
+	IsInternal      bool          `json:"is_internal,omitempty"        desc:"True if the function is marked @internal"`
 }
 
 // hasDocumentation returns true if the FuncDoc has any documentation content.


### PR DESCRIPTION
## Summary

Adds two new opt-in flags to `shdoc-ng generate`:

- `--include-internal` surfaces `@internal` functions in the output. They're marked `is_internal: true` in JSON, and the markdown/HTML templates render an `_(internal)_` suffix next to the function heading so readers can tell them apart from public functions.
- `--include-all` is shorthand for `--include-undocumented --include-internal` — for cases when you want everything (e.g. an internal "full surface" doc).

Default behavior is unchanged: `@internal` functions remain excluded.

## Behavior matrix

| State | default | `--include-undocumented` | `--include-internal` | `--include-all` |
|---|:---:|:---:|:---:|:---:|
| Documented public | yes | yes | yes | yes |
| Bare public (no comments, or comments without doc tags) | no | yes | no | yes |
| Documented `@internal` | no | no | yes (marked) | yes (marked) |
| Bare `@internal` (only `@internal`, no other tags) | no | no | no | yes (marked) |

The bare-add path under `IncludeUndocumented` propagates `IsInternal`, so an `@internal`-only function with both flags on shows up as a bare entry that's still marked internal.

## Changes

- `shdoc/types.go` — new `FuncDoc.IsInternal bool` field (`json:"is_internal,omitempty"`).
- `shdoc/blockparser.go` — new `ParseOptions.IncludeInternal`. `parseFuncBlock`'s `isInternal` early-return is now conditional on the flag; the bare-add path preserves `IsInternal`.
- `shdoc/templates/markdown.tmpl` — `### name` heading gets `_(internal)_` suffix when `IsInternal`.
- `shdoc/templates/html.tmpl` — `<em class="func-internal">(internal)</em>` next to the function name when `IsInternal` (no new CSS required; `<em>` is italic by default).
- `cmd/shdoc-ng/generate.go` — new `--include-internal` and `--include-all` flags wired to `ParseOptions`.
- `schema.json` regenerated (now lists `is_internal` on `FuncDoc`).
- `CLAUDE.md` — one bullet noting the conditional suppression rule.
- `README.md` — flags table and the `@internal` row updated.

## Test plan

- [x] `go test -count=1 ./...` green, including new `TestIncludeInternal` covering: default-excludes, IncludeInternal-only, IncludeInternal+IncludeUndocumented (bare-add preserves the flag), and IncludeUndocumented-only (still excludes `@internal`).
- [x] Smoke-tested on `examples/showcase.sh`: `_private_helper` (the script's `@internal` function) is hidden by default, appears with `"is_internal": true` under `--include-internal`, and the markdown heading reads `### _private_helper _(internal)_`.
- [x] Showcase output (`examples/showcase.{md,html,json}`) byte-identical when regenerated without flags — templates' new branch never fires for non-internal functions.
- [x] Pre-commit hooks (`go-build`, `go-test`, `go-vet`, `golangci-lint`, `go-mod-tidy`, `vscode-extension-build`) all pass.
