### PR TITLE
fix: correct --include-undocumented help text

### DIFF
--- a/cmd/shdoc-ng/generate.go
+++ b/cmd/shdoc-ng/generate.go
@@ -42,7 +42,7 @@ func init() {
 	generateCmd.Flags().StringVarP(&genInputFile, "input", "i", "-", "Input file (- for stdin)")
 	generateCmd.Flags().StringVarP(&genOutputFile, "output", "o", "-", "Output file (- for stdout)")
 	generateCmd.Flags().StringVar(&genTemplateFile, "template", "", "Use a custom template file instead of the built-in one")
-	generateCmd.Flags().BoolVar(&genIncludeUndocumented, "include-undocumented", false, "List functions with no documentation under a synthetic 'Undocumented' section")
+	generateCmd.Flags().BoolVar(&genIncludeUndocumented, "include-undocumented", false, "List functions with no documentation alongside documented ones")
 	rootCmd.AddCommand(generateCmd)
 }
 


### PR DESCRIPTION
## Summary

The cobra flag description for `--include-undocumented` shipped (in v0.8.0) with text describing the original design that never made it in:

> List functions with no documentation under a synthetic 'Undocumented' section

The implemented behavior places bare entries in whichever `@section` is currently active at their declaration — no synthetic bucket. README.md and CLAUDE.md were already using the correct wording; only the `--help` text was stale.

## Change

One-line edit in `cmd/shdoc-ng/generate.go` to match the wording already in the README:

```diff
-      "List functions with no documentation under a synthetic 'Undocumented' section"
+      "List functions with no documentation alongside documented ones"
```

## Test plan

- [x] `go run ./cmd/shdoc-ng generate --help` shows the corrected description.
- [x] `go test -count=1 ./...` green.
- [x] Pre-commit hooks pass.
