### PR TITLE
Use release tag version for VSIX package (#14)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          VERSION=${GITHUB_REF_NAME#v}
           cd editors/vscode
           cp ../../LICENSE .
           npm ci
+          npm version "$VERSION" --no-git-tag-version
           npm run compile
-          npx @vscode/vsce package -o ../../shdoc-ng-${GITHUB_REF_NAME#v}.vsix
+          npx @vscode/vsce package -o ../../shdoc-ng-${VERSION}.vsix
           cd ../..
-          gh release upload ${{ github.ref_name }} shdoc-ng-${GITHUB_REF_NAME#v}.vsix
+          gh release upload ${{ github.ref_name }} shdoc-ng-${VERSION}.vsix
 
   copr:
     needs: goreleaser


### PR DESCRIPTION
Updated the release worfklow so the VSCode extension version is taken from GITHUB_REF_NAME at release time.

Co-authored-by: Codex GPT-5.4 (medium)

@jdevera  I tried to run the release workflow in my fork but it failed with the following error,
so please verify that it actually working.

```
      • error checking for default branch            projectID=jdevera/homebrew-tap statusCode=401 error=GET https://api.github.com/repos/jdevera/homebrew-tap: 401 Bad credentials []
  ⨯ release failed after 1m20s                      
    error=
    │ 1 error occurred:
    │ 	* homebrew formula: could not get default branch: GET https://api.github.com/repos/jdevera/homebrew-tap: 401 Bad credentials []
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.16.0/x64/goreleaser' failed with exit code 1
```

Fixes #14 